### PR TITLE
Customize default settings easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,39 @@ Add a HTML markup:
 
 (See more options in the demos)
 
+## Customize default settings
+
+If you want to modify the default parameters, you need to disable the auto-init procedure first.
+You can do this by adding the following code when importing the plugin scripts:
+
+```
+  <link rel="stylesheet" type="text/css" href="css/jquery-gmaps-latlon-picker.css"/>
+  <script>
+    $.gMapsLatLonPickerNoAutoInit = 1;
+  </script>
+  <script src="js/jquery-gmaps-latlon-picker.js"></script>
+```
+
+Then copy the init code from "jquery-gmaps-latlon-picker.js" and extend it. Here is an example:
+
+```
+<script>
+  $(document).ready(function() {
+    // Copy the init code from "jquery-gmaps-latlon-picker.js" and extend it here
+    $(".gllpLatlonPicker").each(function() {
+      $obj = $(document).gMapsLatLonPicker();
+
+      $obj.params.strings.markerText = "Drag this Marker (example edit)";
+
+      $obj.params.displayError = function(message) {
+        console.log("MAPS ERROR: " + message); // instead of alert()
+      };
+
+      $obj.init( $(this) );
+    });
+  });
+</script>
+```
 
 ## License
 

--- a/js/jquery-gmaps-latlon-picker.js
+++ b/js/jquery-gmaps-latlon-picker.js
@@ -43,6 +43,9 @@ $.fn.gMapsLatLonPicker = (function() {
 			markerText : "Drag this Marker",
 			error_empty_field : "Couldn't find coordinates for this place",
 			error_no_results : "Couldn't find coordinates for this place"
+		},
+		displayError : function(message) {
+			alert(message);
 		}
 	};
 
@@ -116,7 +119,7 @@ $.fn.gMapsLatLonPicker = (function() {
 	var performSearch = function(string, silent) {
 		if (string == "") {
 			if (!silent) {
-				displayError( _self.params.strings.error_empty_field );
+				_self.params.displayError( _self.params.strings.error_empty_field );
 			}
 			return;
 		}
@@ -129,16 +132,11 @@ $.fn.gMapsLatLonPicker = (function() {
 					setPosition( results[0].geometry.location );
 				} else {
 					if (!silent) {
-						displayError( _self.params.strings.error_no_results );
+						_self.params.displayError( _self.params.strings.error_no_results );
 					}
 				}
 			}
 		);
-	};
-
-	// error function
-	var displayError = function(message) {
-		alert(message);
 	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
@@ -223,9 +221,12 @@ $.fn.gMapsLatLonPicker = (function() {
 				_self.vars.map.setZoom( parseInt( $(_self.vars.cssID + ".gllpZoom").val() ) );
 				setPosition(latlng);
 			});
-		}
+		},
 
-	}
+		// EXPORT PARAMS TO EASILY MODIFY THEM ////////////////////////////////////////////////////
+		params : _self.params
+
+	};
 
 	return publicfunc;
 });
@@ -233,9 +234,12 @@ $.fn.gMapsLatLonPicker = (function() {
 }(jQuery));
 
 $(document).ready( function() {
-	$(".gllpLatlonPicker").each(function() {
-		$(document).gMapsLatLonPicker().init( $(this) );
-	});
+	if (!$.gMapsLatLonPickerNoAutoInit) {
+		$(".gllpLatlonPicker").each(function () {
+			$obj = $(document).gMapsLatLonPicker();
+			$obj.init( $(this) );
+		});
+	}
 });
 
 $(document).bind("location_changed", function(event, object) {


### PR DESCRIPTION
This minor refactoring lets us modify the default parameters without editing the original script "jquery-gmaps-latlon-picker.js". This way when the upstream script is updated, we won't have to re-apply our local settings modifications.