### PR TITLE
jQuery scope fix

### DIFF
--- a/js/jquery-gmaps-latlon-picker.js
+++ b/js/jquery-gmaps-latlon-picker.js
@@ -230,9 +230,7 @@ $.fn.gMapsLatLonPicker = (function() {
 
 	return publicfunc;
 });
-
-}(jQuery));
-
+	
 $(document).ready( function() {
 	if (!$.gMapsLatLonPickerNoAutoInit) {
 		$(".gllpLatlonPicker").each(function () {
@@ -245,3 +243,5 @@ $(document).ready( function() {
 $(document).bind("location_changed", function(event, object) {
 	console.log("changed: " + $(object).attr('id') );
 });
+
+}(jQuery));


### PR DESCRIPTION
jQuery scope was fixed on April 16, 2013, but reverted on April 17, 2015, strangely.
This PR fixes that.